### PR TITLE
feat: automatically provide imports object using import map

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The development will be split into multiple stages.
 
 ## Bindings API
 
-When importing a `.wasm` module, unwasm resolves, reads, and then parses the module during the build process to get the information about imports and exports and even tries to [automatically resolve imports](#auto-imports) and generate appropriate code bindings for the bundler. 
+When importing a `.wasm` module, unwasm resolves, reads, and then parses the module during the build process to get the information about imports and exports and even tries to [automatically resolve imports](#auto-imports) and generate appropriate code bindings for the bundler.
 
 If the target environment supports [top level `await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) and also the wasm module requires no imports object (or they are auto resolvable), unwasm generates bindings to allow importing wasm module like any other ESM import.
 
@@ -180,9 +180,6 @@ To hint to the bundler how to resolve imports needed by the `.wasm` file, you ne
 
 ```js
 {
-  "name": "@fixture/wasm",
-  "version": "1.0.0",
-  "type": "module",
   "exports": {
     "./rand.wasm": "./rand.wasm"
   },

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ The development will be split into multiple stages.
 - [ ] ESM Loader ([unjs/unwasm#5](https://github.com/unjs/unwasm/issues/5))
 - [ ] Integration with [Wasmer](https://github.com/wasmerio) ([unjs/unwasm#6](https://github.com/unjs/unwasm/issues/6))
 - [ ] Convention for library authors exporting wasm modules ([unjs/unwasm#7](https://github.com/unjs/unwasm/issues/7))
-  - [x] Auto resolve imports from imports map
+  - [x] Auto resolve imports from the imports map
 
 ## Bindings API
 
-When importing a `.wasm` module, unwasm resolves, reads, and then parses the module during build process to get the information about imports and exports and generate appropriate code bindings.
+When importing a `.wasm` module, unwasm resolves, reads, and then parses the module during the build process to get the information about imports and exports and even tries to [automatically resolve imports](#auto-imports) and generate appropriate code bindings for the bundler. 
 
-If the target environment supports [top level `await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) and also the wasm module requires no imports object (auto-detected after parsing), unwasm generates bindings to allow importing wasm module like any other ESM import.
+If the target environment supports [top level `await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#top_level_await) and also the wasm module requires no imports object (or they are auto resolvable), unwasm generates bindings to allow importing wasm module like any other ESM import.
 
-If the target environment lacks support for top level `await` or the wasm module requires imports object or `lazy` plugin option is set to `true`, unwasm will export a wrapped [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) object which can be called as a function to lazily evaluate the module with custom imports object. This way we still have a simple syntax as close as possible to ESM modules and also we can lazily initialize modules.
+If the target environment lacks support for top-level `await` or the wasm module requires an imports object or `lazy` plugin option is set to `true`, unwasm will export a wrapped [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) object which can be called as a function to evaluate the module with custom imports object lazily. This way we still have a simple syntax as close as possible to ESM modules and also we can lazily initialize modules.
 
 **Example:** Using static import
 
@@ -47,7 +47,7 @@ import { sum } from "unwasm/examples/sum.wasm";
 const { sum } = await import("unwasm/examples/sum.wasm");
 ```
 
-If your WebAssembly module requires an import object (which is likely!), the usage syntax would be slightly different as we need to initiate the module with an import object first.
+If your WebAssembly module requires an import object (unwasm can [automatically infer them](#auto-imports)), the usage syntax would be slightly different as we need to initiate the module with an import object first.
 
 **Example:** Using dynamic import with imports object
 
@@ -174,7 +174,7 @@ Example parsed result:
 
 unwasm can automatically infer the imports object and bundle them using imports maps (read more: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap), [Node.js](https://nodejs.org/api/packages.html#imports) and [WICG](https://github.com/WICG/import-maps)).
 
-In order to hint the bundler how to resolve imports needed by the `.wasm` file, you need to define them in a parent `package.json` file.
+To hint to the bundler how to resolve imports needed by the `.wasm` file, you need to define them in a parent `package.json` file.
 
 **Example:**
 
@@ -192,7 +192,7 @@ In order to hint the bundler how to resolve imports needed by the `.wasm` file, 
 }
 ```
 
-**Note:** The imports can be also prefixed with `#` like `#env` if you like to respect Node.js conventions.
+**Note:** The imports can also be prefixed with `#` like `#env` if you like to respect Node.js conventions.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The development will be split into multiple stages.
 - [ ] ESM Loader ([unjs/unwasm#5](https://github.com/unjs/unwasm/issues/5))
 - [ ] Integration with [Wasmer](https://github.com/wasmerio) ([unjs/unwasm#6](https://github.com/unjs/unwasm/issues/6))
 - [ ] Convention for library authors exporting wasm modules ([unjs/unwasm#7](https://github.com/unjs/unwasm/issues/7))
+  - [x] Auto resolve imports from imports map
 
 ## Bindings API
 
@@ -168,6 +169,30 @@ Example parsed result:
   ]
 }
 ```
+
+## Auto Imports
+
+unwasm can automatically infer the imports object and bundle them using imports maps (read more: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap), [Node.js](https://nodejs.org/api/packages.html#imports) and [WICG](https://github.com/WICG/import-maps)).
+
+In order to hint the bundler how to resolve imports needed by the `.wasm` file, you need to define them in a parent `package.json` file.
+
+**Example:**
+
+```js
+{
+  "name": "@fixture/wasm",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    "./rand.wasm": "./rand.wasm"
+  },
+  "imports": {
+    "env": "./env.mjs"
+  }
+}
+```
+
+**Note:** The imports can be also prefixed with `#` like `#env` if you like to respect Node.js conventions.
 
 ## Development
 

--- a/examples/env.mjs
+++ b/examples/env.mjs
@@ -1,0 +1,1 @@
+export const seed = () => Math.random() * Date.now()

--- a/examples/package.json
+++ b/examples/package.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "#env": "./env.mjs"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "magic-string": "^0.30.5",
     "mlly": "^1.4.2",
     "pathe": "^1.1.1",
+    "pkg-types": "^1.0.3",
     "unplugin": "^1.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "files": [
     "dist",
     "*.d.ts",
-    "examples/*.wasm"
+    "examples/*.wasm",
+    "examples/package.json",
+    "examples/*.mjs"
   ],
   "scripts": {
     "build": "unbuild && pnpm build:examples",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   pathe:
     specifier: ^1.1.1
     version: 1.1.1
+  pkg-types:
+    specifier: ^1.0.3
+    version: 1.0.3
   unplugin:
     specifier: ^1.6.0
     version: 1.6.0

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -93,7 +93,7 @@ const unplugin = createUnplugin<UnwasmPluginOptions>((opts) => {
       const buff = await fs.readFile(id);
       return buff.toString("binary");
     },
-    transform(code, id) {
+    async transform(code, id) {
       if (!id.endsWith(".wasm")) {
         return;
       }
@@ -111,7 +111,7 @@ const unplugin = createUnplugin<UnwasmPluginOptions>((opts) => {
       });
 
       return {
-        code: getWasmBinding(asset, opts),
+        code: await getWasmBinding(asset, opts),
         map: { mappings: "" },
       };
     },

--- a/src/plugin/runtime.ts
+++ b/src/plugin/runtime.ts
@@ -42,8 +42,7 @@ function _instantiate(imports = _imports) {
   `;
 
   // --- Binding code to export the wasm module exports ---
-  const canTopAwait =
-    opts.lazy !== true && Object.keys(asset.imports).length === 0;
+  const canTopAwait = opts.lazy !== true;
 
   // eslint-disable-next-line unicorn/prefer-ternary
   if (canTopAwait) {

--- a/src/plugin/runtime.ts
+++ b/src/plugin/runtime.ts
@@ -23,12 +23,7 @@ ${autoImports};
 
 async function _instantiate(imports = _imports) {
   const _mod = await import("${UNWASM_EXTERNAL_PREFIX}${asset.name}").then(r => r.default || r);
-  try {
-    return await WebAssembly.instantiate(_mod, imports)
-  } catch (error) {
-    console.error('[wasm] [error]', error);
-    throw error;
-  }
+  return WebAssembly.instantiate(_mod, imports)
 }
   `
     : js`

--- a/test/fixture/_shared.mjs
+++ b/test/fixture/_shared.mjs
@@ -1,6 +1,0 @@
-export const imports = {
-  env: {
-    // eslint-disable-next-line unicorn/consistent-function-scoping
-    seed: () => () => Math.random() * Date.now(),
-  },
-};

--- a/test/fixture/dynamic-import.mjs
+++ b/test/fixture/dynamic-import.mjs
@@ -1,8 +1,6 @@
 const { sum } = await import("@fixture/wasm/sum.wasm");
-
-const { imports } = await import("./_shared.mjs");
 const { rand } = await import("@fixture/wasm/rand.wasm").then((r) =>
-  r.default(imports),
+  r.default(),
 );
 
 export function test() {

--- a/test/fixture/dynamic-import.mjs
+++ b/test/fixture/dynamic-import.mjs
@@ -1,12 +1,11 @@
+const { rand } = await import("@fixture/wasm/rand.wasm");
 const { sum } = await import("@fixture/wasm/sum.wasm");
-const { rand } = await import("@fixture/wasm/rand.wasm").then((r) =>
-  r.default(),
-);
 
 export function test() {
-  if (sum(1, 2) !== 3) {
-    return "FALED: sum";
-  }
+  // Seems a bug with Miniflare and two async functions...
+  // if (sum(1, 2) !== 3) {
+  //   return "FALED: sum";
+  // }
   if (!(rand(0, 1000) > 0)) {
     return "FALED: rand";
   }

--- a/test/fixture/dynamic-import.mjs
+++ b/test/fixture/dynamic-import.mjs
@@ -1,11 +1,12 @@
-const { rand } = await import("@fixture/wasm/rand.wasm");
-const { sum } = await import("@fixture/wasm/sum.wasm");
+export async function test() {
+  // Avoid top-level await because of miniflare curren't limitation.
+  // https://github.com/cloudflare/miniflare/issues/753
+  const { rand } = await import("@fixture/wasm/rand.wasm");
+  const { sum } = await import("@fixture/wasm/sum.wasm");
 
-export function test() {
-  // Seems a bug with Miniflare and two async functions...
-  // if (sum(1, 2) !== 3) {
-  //   return "FALED: sum";
-  // }
+  if (sum(1, 2) !== 3) {
+    return "FALED: sum";
+  }
   if (!(rand(0, 1000) > 0)) {
     return "FALED: rand";
   }

--- a/test/fixture/static-import.mjs
+++ b/test/fixture/static-import.mjs
@@ -1,7 +1,5 @@
 import { sum } from "@fixture/wasm/sum.wasm";
-import initRand, { rand } from "@fixture/wasm/rand.wasm";
-
-await initRand();
+import { rand } from "@fixture/wasm/rand.wasm";
 
 export function test() {
   if (sum(1, 2) !== 3) {

--- a/test/fixture/static-import.mjs
+++ b/test/fixture/static-import.mjs
@@ -1,8 +1,7 @@
-import { imports } from "./_shared.mjs";
 import { sum } from "@fixture/wasm/sum.wasm";
 import initRand, { rand } from "@fixture/wasm/rand.wasm";
 
-await initRand(imports);
+await initRand();
 
 export function test() {
   if (sum(1, 2) !== 3) {

--- a/test/node_modules/@fixture/wasm/env.mjs
+++ b/test/node_modules/@fixture/wasm/env.mjs
@@ -1,0 +1,1 @@
+export const seed = () => Math.random() * Date.now()

--- a/test/node_modules/@fixture/wasm/package.json
+++ b/test/node_modules/@fixture/wasm/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "exports": {
     "./*": "./*"
+  },
+  "imports": {
+    "#env": "./env.mjs"
   }
 }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -68,7 +68,7 @@ async function _evalCloudflare(name: string) {
 import { test } from "./index.mjs";
 export default {
   async fetch(request, env, ctx) {
-    return new Response(test());
+    return new Response(await test());
   }
 }
 `,


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #10

This PR eliminates the need for users to directly pass import objects.

Using imports map, we directly guide rollup to bundle the imports object into the binding.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
