### PR TITLE
feat: support `?module` suffix for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ await initRand({
 > [!NOTE]
 > When using **static import syntax**, and before initializing the module, the named exports will be wrapped into a function by proxy that waits for the module initialization and if called before init, will immediately try to call init without imports and return a Promise that calls a function after init.
 
+### Module compatibility
+
+There are situations where libraries require a [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module) instance to initialize [`WebAssembly.Instance`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Instance/Instance) themselves. In order to maximize compatibility, unwasm allows a specific import suffix `?module` to import `.wasm` files as a Module directly.
+
+```js
+import _sumMod from "unwasm/examples/sum.wasm";
+const { sum } = await WebAssembly.instantiate(_sumMod).then((i) => i.exports);
+```
+
+> [!NOTE]
+> Open [an issue](https://github.com/unjs/unwasm/issues/new/choose) to us! We would love to help those libraries to migrate!
+
 ## Integration
 
 Unwasm needs to transform the `.wasm` imports to the compatible bindings. Currently, the only method is using a rollup plugin. In the future, more usage methods will be introduced.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ await initRand({
 There are situations where libraries require a [`WebAssembly.Module`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Module) instance to initialize [`WebAssembly.Instance`](https://developer.mozilla.org/en-US/docs/WebAssembly/JavaScript_interface/Instance/Instance) themselves. In order to maximize compatibility, unwasm allows a specific import suffix `?module` to import `.wasm` files as a Module directly.
 
 ```js
-import _sumMod from "unwasm/examples/sum.wasm";
+import _sumMod from "unwasm/examples/sum.wasm?module";
 const { sum } = await WebAssembly.instantiate(_sumMod).then((i) => i.exports);
 ```
 

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -116,10 +116,12 @@ const unplugin = createUnplugin<UnwasmPluginOptions>((opts) => {
         return;
       }
 
+      const buff = Buffer.from(code, "binary");
+
       const isModule = id.endsWith("?module");
 
-      const buff = Buffer.from(code, "binary");
       const name = `wasm/${basename(id.split("?")[0], ".wasm")}-${sha1(buff)}.wasm`;
+
       const parsed = isModule
         ? { imports: [], exports: ["default"] }
         : parse(name, buff);

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -116,9 +116,13 @@ const unplugin = createUnplugin<UnwasmPluginOptions>((opts) => {
         return;
       }
 
+      const isModule = id.endsWith("?module");
+
       const buff = Buffer.from(code, "binary");
-      const name = `wasm/${basename(id, ".wasm")}-${sha1(buff)}.wasm`;
-      const parsed = parse(name, buff);
+      const name = `wasm/${basename(id.split("?")[0], ".wasm")}-${sha1(buff)}.wasm`;
+      const parsed = isModule
+        ? { imports: [], exports: ["default"] }
+        : parse(name, buff);
 
       const asset = (assets[name] = <WasmAsset>{
         name,
@@ -129,7 +133,7 @@ const unplugin = createUnplugin<UnwasmPluginOptions>((opts) => {
       });
 
       return {
-        code: id.endsWith("?module")
+        code: isModule
           ? await getWasmModuleBinding(asset, opts)
           : await getWasmESMBinding(asset, opts),
         map: { mappings: "" },

--- a/src/plugin/runtime.ts
+++ b/src/plugin/runtime.ts
@@ -9,7 +9,10 @@ import {
 // https://marketplace.visualstudio.com/items?itemName=Tobermory.es6-string-html
 const js = String.raw;
 
-export async function getWasmBinding(
+/**
+ * Returns ESM compatible exports binding
+ */
+export async function getWasmESMBinding(
   asset: WasmAsset,
   opts: UnwasmPluginOptions,
 ) {
@@ -71,6 +74,26 @@ ${asset.exports
 export default _mod;
     `;
   }
+}
+
+/**
+ * Returns WebAssembly.Module binding for compatibility
+ */
+export function getWasmModuleBinding(
+  asset: WasmAsset,
+  opts: UnwasmPluginOptions,
+) {
+  return opts.esmImport
+    ? js`
+const _mod = await import("${UNWASM_EXTERNAL_PREFIX}${asset.name}").then(r => r.default || r);
+export default _mod;
+  `
+    : js`
+import { base64ToUint8Array } from "${UMWASM_HELPERS_ID}";
+const _data = base64ToUint8Array("${asset.source.toString("base64")}");
+const _mod = new WebAssembly.Module(_data);
+export default _mod;
+  `;
 }
 
 export function getPluginUtils() {

--- a/src/plugin/runtime.ts
+++ b/src/plugin/runtime.ts
@@ -85,7 +85,7 @@ export function getWasmModuleBinding(
 ) {
   return opts.esmImport
     ? js`
-const _mod = await import("${UNWASM_EXTERNAL_PREFIX}${asset.name}").then(r => r.default || r);
+const _mod = ${opts.lazy === true ? "" : `await`} import("${UNWASM_EXTERNAL_PREFIX}${asset.name}").then(r => r.default || r);
 export default _mod;
   `
     : js`

--- a/test/fixture/module-import.mjs
+++ b/test/fixture/module-import.mjs
@@ -1,6 +1,6 @@
 import _sumMod from "@fixture/wasm/sum.wasm?module";
 
-const { sum } = await WebAssembly.instantiate(_sumMod).then(i => i.exports);
+const { sum } = await WebAssembly.instantiate(_sumMod).then((i) => i.exports);
 
 export function test() {
   if (sum(1, 2) !== 3) {

--- a/test/fixture/module-import.mjs
+++ b/test/fixture/module-import.mjs
@@ -1,0 +1,10 @@
+import _sumMod from "@fixture/wasm/sum.wasm?module";
+
+const { sum } = await WebAssembly.instantiate(_sumMod).then(i => i.exports);
+
+export function test() {
+  if (sum(1, 2) !== 3) {
+    return "FALED: sum";
+  }
+  return "OK";
+}

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -37,6 +37,17 @@ describe("plugin:rollup", () => {
     const resText = await _evalCloudflare(name).then((r) => r.text());
     expect(resText).toBe("OK");
   });
+
+  it("module", async () => {
+    const { output } = await _rollupBuild(
+      "fixture/module-import.mjs",
+      "rollup-module",
+      {},
+    );
+    const code = output[0].code;
+    const mod = await evalModule(code, { url: r("fixture/rollup-module.mjs") });
+    expect(mod.test()).toBe("OK");
+  });
 });
 
 // --- Utils ---


### PR DESCRIPTION
This PR adds support to access `WebAssembly.Module` instance using `?module` suffix.

While ideally aim of this project is to help more libraries migrate to ESM, upgrading ecosystem takes time and it can help to adopt `unwasm` without strict requirements.

