### PR TITLE
fix(plugin): narrow `.wasm` extension matcher

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -18,7 +18,7 @@ import {
 
 export type { UnwasmPluginOptions } from "./shared";
 
-const WASM_ID_RE = /\.wasm\??.*$/i;
+const WASM_ID_RE = /\.wasm(?:\?.*)?$/i;
 
 export function unwasm(opts: UnwasmPluginOptions): Plugin {
   const assets: Record<string, WasmAsset> = Object.create(null);


### PR DESCRIPTION
resolves #80 (not fully verified as i have no simple reproduction)

This PR fixes matcher regex to avoid matching imports like `foo/bar.wasm-xyz.mjs`, `foo/bar.wasm123`, or `foo/bar.wasm.js`