### PR TITLE
fix: add missing 0xfc-prefix wasm opcodes to parser patch

### DIFF
--- a/lib/wasm-parser.mjs
+++ b/lib/wasm-parser.mjs
@@ -3029,9 +3029,9 @@ var require_signatures = __commonJS({
   }
 });
 
-// node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/section.js
+// node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/section.js
 var require_section = __commonJS({
-  "node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/section.js"(exports) {
+  "node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/section.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3064,9 +3064,9 @@ var require_section = __commonJS({
   }
 });
 
-// node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/index.js
+// node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/index.js
 var require_lib6 = __commonJS({
-  "node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/index.js"(exports) {
+  "node_modules/.pnpm/@webassemblyjs+helper-wasm-bytecode@1.14.1_patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185/node_modules/@webassemblyjs/helper-wasm-bytecode/lib/index.js"(exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
       value: true
@@ -3448,13 +3448,25 @@ var require_lib6 = __commonJS({
       65100: createSymbolObject("atomic.rmw8_u.cmpxchg_u", "i64", 1),
       65101: createSymbolObject("atomic.rmw16_u.cmpxchg_u", "i64", 1),
       65102: createSymbolObject("atomic.rmw32_u.cmpxchg_u", "i64", 1),
-      // FC (misc prefix) — saturating trunc + bulk-mem
-      64519: createSymbolObject("trunc_sat_f64_u", "i64", 0),
-      // i64.trunc_sat_f64_u
+      // Bulk memory instructions
+      64520: createSymbol("memory.init", 2),
+      64521: createSymbol("data.drop", 1),
+      64522: createSymbol("memory.copy", 2),
+      64523: createSymbol("memory.fill", 1),
+      // Non-trapping float-to-int conversions (0xfc00–0xfc07)
+      64512: createSymbolObject("trunc_sat_f32_s", "i32", 0),
+      64513: createSymbolObject("trunc_sat_f32_u", "i32", 0),
+      64514: createSymbolObject("trunc_sat_f64_s", "i32", 0),
       64515: createSymbolObject("trunc_sat_f64_u", "i32", 0),
-      // i32.trunc_sat_f64_u
+      64516: createSymbolObject("trunc_sat_f32_s", "i64", 0),
+      64517: createSymbolObject("trunc_sat_f32_u", "i64", 0),
       64518: createSymbolObject("trunc_sat_f64_s", "i64", 0),
-      // i64.trunc_sat_f64_s
+      64519: createSymbolObject("trunc_sat_f64_u", "i64", 0),
+      // Wide arithmetic proposal (0xfc13–0xfc16)
+      64531: createSymbolObject("add128", "i64", 0),
+      64532: createSymbolObject("sub128", "i64", 0),
+      64533: createSymbolObject("mul_wide_s", "i64", 0),
+      64534: createSymbolObject("mul_wide_u", "i64", 0),
       // Core + Exception Handling (EH) proposal
       0: createSymbolObject("unreachable", "void", 0),
       6: createSymbolObject("try", "block", 1),

--- a/patches/@webassemblyjs__helper-wasm-bytecode.patch
+++ b/patches/@webassemblyjs__helper-wasm-bytecode.patch
@@ -1,18 +1,35 @@
 diff --git a/lib/index.js b/lib/index.js
-index 7390d66de519bc3c9a8b0cadb6ff35176d54a32d..b0a829afd5f8c3c54c91b9639aaee16d02d698c8 100644
+index 7390d66de519bc3c9a8b0cadb6ff35176d54a32d..0000000000000000000000000000000000000000 100644
 --- a/lib/index.js
 +++ b/lib/index.js
-@@ -401,7 +401,35 @@ var symbolsByByte = {
+@@ -401,7 +401,52 @@ var symbolsByByte = {
    0xfe4b: createSymbolObject("atomic.rmw16_u.cmpxchg_u", "i32", 1),
    0xfe4c: createSymbolObject("atomic.rmw8_u.cmpxchg_u", "i64", 1),
    0xfe4d: createSymbolObject("atomic.rmw16_u.cmpxchg_u", "i64", 1),
 -  0xfe4e: createSymbolObject("atomic.rmw32_u.cmpxchg_u", "i64", 1)
 +  0xfe4e: createSymbolObject("atomic.rmw32_u.cmpxchg_u", "i64", 1),
 +
-+  // FC (misc prefix) — saturating trunc + bulk-mem
-+  0xfc07: createSymbolObject("trunc_sat_f64_u", "i64", 0), // i64.trunc_sat_f64_u
-+  0xfc03: createSymbolObject("trunc_sat_f64_u", "i32", 0), // i32.trunc_sat_f64_u
-+  0xfc06: createSymbolObject("trunc_sat_f64_s", "i64", 0), // i64.trunc_sat_f64_s
++  // Bulk memory instructions
++  0xfc08: createSymbol("memory.init", 2),
++  0xfc09: createSymbol("data.drop", 1),
++  0xfc0a: createSymbol("memory.copy", 2),
++  0xfc0b: createSymbol("memory.fill", 1),
++
++  // Non-trapping float-to-int conversions (0xfc00–0xfc07)
++  0xfc00: createSymbolObject("trunc_sat_f32_s", "i32", 0),
++  0xfc01: createSymbolObject("trunc_sat_f32_u", "i32", 0),
++  0xfc02: createSymbolObject("trunc_sat_f64_s", "i32", 0),
++  0xfc03: createSymbolObject("trunc_sat_f64_u", "i32", 0),
++  0xfc04: createSymbolObject("trunc_sat_f32_s", "i64", 0),
++  0xfc05: createSymbolObject("trunc_sat_f32_u", "i64", 0),
++  0xfc06: createSymbolObject("trunc_sat_f64_s", "i64", 0),
++  0xfc07: createSymbolObject("trunc_sat_f64_u", "i64", 0),
++
++  // Wide arithmetic proposal (0xfc13–0xfc16)
++  0xfc13: createSymbolObject("add128", "i64", 0),
++  0xfc14: createSymbolObject("sub128", "i64", 0),
++  0xfc15: createSymbolObject("mul_wide_s", "i64", 0),
++  0xfc16: createSymbolObject("mul_wide_u", "i64", 0),
 +
 +  // Core + Exception Handling (EH) proposal
 +  0x0:   createSymbolObject("unreachable", "void", 0),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
 
 patchedDependencies:
   '@webassemblyjs/helper-wasm-bytecode':
-    hash: 339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101
+    hash: 1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185
     path: patches/@webassemblyjs__helper-wasm-bytecode.patch
 
 importers:
@@ -3470,7 +3470,7 @@ snapshots:
   '@webassemblyjs/ast@1.14.1':
     dependencies:
       '@webassemblyjs/helper-numbers': 1.13.2
-      '@webassemblyjs/helper-wasm-bytecode': 1.14.1(patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101)
+      '@webassemblyjs/helper-wasm-bytecode': 1.14.1(patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185)
 
   '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
 
@@ -3482,7 +3482,7 @@ snapshots:
       '@webassemblyjs/helper-api-error': 1.13.2
       '@xtuc/long': 4.2.2
 
-  '@webassemblyjs/helper-wasm-bytecode@1.14.1(patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101)': {}
+  '@webassemblyjs/helper-wasm-bytecode@1.14.1(patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185)': {}
 
   '@webassemblyjs/ieee754@1.14.1':
     dependencies:
@@ -3498,7 +3498,7 @@ snapshots:
     dependencies:
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/helper-api-error': 1.13.2
-      '@webassemblyjs/helper-wasm-bytecode': 1.14.1(patch_hash=339774429611ed34bc80bc6bbe80b2e7a85c850a1f7612f4e8d36151bf486101)
+      '@webassemblyjs/helper-wasm-bytecode': 1.14.1(patch_hash=1f536d6e0ffd330fd4e93fa13b112099cb075736b33e1915a194b492ee3ff185)
       '@webassemblyjs/ieee754': 1.14.1
       '@webassemblyjs/leb128': 1.14.1
       '@webassemblyjs/utf8': 1.14.1


### PR DESCRIPTION
## Summary

- Extend `@webassemblyjs/helper-wasm-bytecode` patch with full `0xfc` opcode family
- Add bulk-memory ops (`memory.init`, `data.drop`, `memory.copy`, `memory.fill`) with correct immediate counts
- Add all non-trapping float-to-int conversions (`0xfc00`–`0xfc07`)
- Add wide-arithmetic opcodes (`0xfc13`–`0xfc16`)

Fixes #92

## Root cause

The bundled parser only mapped three `0xfc` opcodes. Modern Rust/wasm-bindgen toolchains emit `0xfc00` (`i32.trunc_sat_f32_s`) and other bulk-memory ops by default, causing `Unexpected instruction: 0xfc00` parse failures.

## Test plan

- [x] `pnpm vitest run` passes (11 tests)
- [x] `@cf-wasm/photon@0.3.5` wasm module parses successfully (previously threw on `0xfc00`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced WebAssembly decoder to support bulk-memory operations, non-trapping float-to-int conversions, and wide arithmetic instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unwasm/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->