### PR TITLE
fix(plugin): fall back to module mode when a binary cannot be parsed

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -33,19 +33,19 @@ export function unwasm(opts: UnwasmPluginOptions): UnwasmPlugin {
     const imports: Record<string, string[]> = Object.create(null);
     const exports: string[] = [];
 
-    try {
-      const parsed = parseWasm(source, { name });
-      for (const mod of parsed.modules) {
-        exports.push(...mod.exports.map((e) => e.name));
-        for (const imp of mod.imports) {
-          if (!imports[imp.module]) {
-            imports[imp.module] = [];
-          }
-          imports[imp.module].push(imp.name);
+    // Let the caller handle a failure: an empty interface is indistinguishable
+    // from a module that genuinely has none, and binding to it would emit an
+    // instantiation that cannot succeed. Nothing is cached in that case, so a
+    // later parse of the same asset is not answered from a failed one.
+    const parsed = parseWasm(source, { name });
+    for (const mod of parsed.modules) {
+      exports.push(...mod.exports.map((e) => e.name));
+      for (const imp of mod.imports) {
+        if (!imports[imp.module]) {
+          imports[imp.module] = [];
         }
+        imports[imp.module].push(imp.name);
       }
-    } catch (error) {
-      console.warn(`[unwasm] Failed to parse WASM module ${name}:`, error);
     }
 
     _parseCache[name] = {

--- a/test/parse-fallback.test.ts
+++ b/test/parse-fallback.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { unwasm, type UnwasmPluginOptions } from "../src/plugin";
+
+/**
+ * A module the reader cannot decode, but which the engine may still accept.
+ *
+ * The import section declares one entry with kind `0x09`. Import kinds are
+ * open ended (each proposal adds one), and the descriptor that follows is kind
+ * specific, so an unknown kind leaves no way to find the next import — the
+ * reader has to give up rather than guess.
+ */
+function unparsableWasm(): Buffer {
+  const section = (id: number, contents: number[]) => [id, contents.length, ...contents];
+  return Buffer.from([
+    // "\0asm", version 1
+    0x00,
+    0x61,
+    0x73,
+    0x6d,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    // type: [() -> ()]
+    ...section(1, [0x01, 0x60, 0x00, 0x00]),
+    // import: "env" "f", kind 0x09
+    ...section(2, [0x01, 0x03, 0x65, 0x6e, 0x76, 0x01, 0x66, 0x09]),
+    // export: "a" (func 0)
+    ...section(7, [0x01, 0x01, 0x61, 0x00, 0x00]),
+  ]);
+}
+
+const ID = "/fixture/unparsable.wasm";
+
+/** Drive the transform hook directly, capturing the warnings it emits. */
+function createTransform(opts: UnwasmPluginOptions = {}) {
+  const warnings: { message?: string }[] = [];
+  const handler = unwasm(opts).transform.handler as unknown as (
+    this: unknown,
+    code: string,
+    id: string,
+  ) => Promise<{ code: string }>;
+  const ctx = {
+    warn(warning: { message?: string }) {
+      warnings.push(warning);
+    },
+  };
+  return {
+    warnings,
+    transform: (source: Buffer) => handler.call(ctx, source.toString("binary"), ID),
+  };
+}
+
+describe("unparsable binaries", () => {
+  it("falls back to module mode instead of binding to an empty interface", async () => {
+    const { transform, warnings } = createTransform();
+    const { code } = await transform(unparsableWasm());
+
+    // Module mode hands the binary to the engine, which knows the kinds the
+    // reader does not.
+    expect(code).toContain("new WebAssembly.Module");
+    expect(code).toContain("export default _mod");
+
+    // The failing path: instantiating with an interface derived from a parse
+    // that never succeeded. The module declares an import, so an empty
+    // `_imports` throws at instantiation — at module scope, before the app
+    // serves anything.
+    expect(code).not.toContain("no imports");
+    expect(code).not.toContain("_instantiate");
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].message).toContain("module mode");
+  });
+
+  it("keeps falling back when the same asset is transformed again", async () => {
+    // Parse results are cached per asset, so a second build of the same
+    // binary must not read a cache entry that looks like a successful parse.
+    const { transform } = createTransform();
+    const source = unparsableWasm();
+
+    const first = await transform(source);
+    const second = await transform(source);
+
+    expect(second.code).toBe(first.code);
+    expect(second.code).toContain("new WebAssembly.Module");
+  });
+
+  it("stays silent when `silent` is set", async () => {
+    const { transform, warnings } = createTransform({ silent: true });
+    await transform(unparsableWasm());
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/test/parse-fallback.test.ts
+++ b/test/parse-fallback.test.ts
@@ -1,17 +1,33 @@
 import { describe, expect, it } from "vitest";
 import { unwasm, type UnwasmPluginOptions } from "../src/plugin";
+import { parseWasm } from "../src/tools/parser";
+
+const uleb128 = (value: number): number[] => {
+  const bytes: number[] = [];
+  do {
+    let byte = value & 0x7f;
+    value >>>= 7;
+    if (value) {
+      byte |= 0x80;
+    }
+    bytes.push(byte);
+  } while (value);
+  return bytes;
+};
+
+const section = (id: number, contents: number[]) => [id, ...uleb128(contents.length), ...contents];
+const name = (value: string) => [value.length, ...Buffer.from(value, "utf8")];
 
 /**
- * A module the reader cannot decode, but which the engine may still accept.
+ * A module the reader cannot decode, but which the engine accepts.
  *
- * The import section declares one entry with kind `0x09`. Import kinds are
- * open ended (each proposal adds one), and the descriptor that follows is kind
- * specific, so an unknown kind leaves no way to find the next import — the
- * reader has to give up rather than guess.
+ * The imported global is typed `(ref null func)`, a typed reference from the
+ * function references proposal. Its `0x63` prefix is followed by a heap type
+ * whose width the reader cannot know in general, so guessing it would desync
+ * every import after it — the reader has to give up rather than guess.
  */
-function unparsableWasm(): Buffer {
-  const section = (id: number, contents: number[]) => [id, contents.length, ...contents];
-  return Buffer.from([
+function unparsableWasm(): Uint8Array<ArrayBuffer> {
+  return new Uint8Array([
     // "\0asm", version 1
     0x00,
     0x61,
@@ -21,12 +37,12 @@ function unparsableWasm(): Buffer {
     0x00,
     0x00,
     0x00,
-    // type: [() -> ()]
-    ...section(1, [0x01, 0x60, 0x00, 0x00]),
-    // import: "env" "f", kind 0x09
-    ...section(2, [0x01, 0x03, 0x65, 0x6e, 0x76, 0x01, 0x66, 0x09]),
-    // export: "a" (func 0)
-    ...section(7, [0x01, 0x01, 0x61, 0x00, 0x00]),
+    // import: "env" "g", global (ref null func), immutable
+    ...section(2, [0x01, ...name("env"), ...name("g"), 0x03, 0x63, 0x70, 0x00]),
+    // memory: one page, so the module has something to export
+    ...section(5, [0x01, 0x00, 0x01]),
+    // export: "m" (memory 0)
+    ...section(7, [0x01, ...name("m"), 0x02, 0x00]),
   ]);
 }
 
@@ -47,26 +63,48 @@ function createTransform(opts: UnwasmPluginOptions = {}) {
   };
   return {
     warnings,
-    transform: (source: Buffer) => handler.call(ctx, source.toString("binary"), ID),
+    transform: (source: Uint8Array) =>
+      handler.call(ctx, Buffer.from(source).toString("binary"), ID),
   };
 }
 
+/** Run the inlined base64 payload of a generated module binding. */
+function compileGeneratedModule(code: string): WebAssembly.Module {
+  const [, base64] = /base64ToUint8Array\("([^"]*)"\)/.exec(code) || [];
+  expect(base64).toBeDefined();
+  return new WebAssembly.Module(new Uint8Array(Buffer.from(base64, "base64")));
+}
+
 describe("unparsable binaries", () => {
+  it("is a binary the engine accepts and the reader rejects", () => {
+    // Both halves of the premise, so this stays a fallback test rather than
+    // silently becoming a test about a binary nobody can load.
+    const source = unparsableWasm();
+    expect(WebAssembly.validate(source)).toBe(true);
+    expect(WebAssembly.Module.imports(new WebAssembly.Module(source))).toEqual([
+      { module: "env", name: "g", kind: "global" },
+    ]);
+    expect(() => parseWasm(source)).toThrow(/typed reference/);
+  });
+
   it("falls back to module mode instead of binding to an empty interface", async () => {
     const { transform, warnings } = createTransform();
     const { code } = await transform(unparsableWasm());
 
-    // Module mode hands the binary to the engine, which knows the kinds the
-    // reader does not.
+    // Module mode hands the binary to the engine, which knows the types the
+    // reader does not, so the generated binding still compiles.
     expect(code).toContain("new WebAssembly.Module");
     expect(code).toContain("export default _mod");
+    expect(WebAssembly.Module.exports(compileGeneratedModule(code))).toEqual([
+      { name: "m", kind: "memory" },
+    ]);
 
     // The failing path: instantiating with an interface derived from a parse
     // that never succeeded. The module declares an import, so an empty
     // `_imports` throws at instantiation — at module scope, before the app
     // serves anything.
-    expect(code).not.toContain("no imports");
     expect(code).not.toContain("_instantiate");
+    await expect(WebAssembly.instantiate(unparsableWasm(), {})).rejects.toThrow();
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0].message).toContain("module mode");


### PR DESCRIPTION
## Problem

When the WebAssembly reader cannot decode a binary, the build emits an ESM binding that cannot possibly instantiate — and the failure surfaces at module scope in production, not at build time.

`parse()` catches the decoder error, `console.warn`s it, and then caches and returns the *empty* accumulators:

```js
} catch (error) {
  console.warn(`[unwasm] Failed to parse WASM module ${name}:`, error);
}
_parseCache[name] = { imports, exports };  // both empty on failure
```

An empty result is indistinguishable from a module that genuinely has no imports, so both existing fallbacks are bypassed:

- The `try`/`catch` around `parse()` in `transform` only fires if `parse` **throws**, which it never does. Its `isModule = true` branch is unreachable for a parse failure.
- `getWasmImports` sees `importNames.length === 0` and returns `{ code: "const _imports = { /* no imports */ }", resolved: true }` — a *successful* resolution — so the `getWasmESMBinding(...).catch(...)` fallback does not fire either.

The eager binding is emitted, and for a module that does declare imports, `WebAssembly.instantiate` throws under a top-level `await` at module scope:

```
WebAssembly.instantiate(): Import #0 "env": module is not an object or function
```

On a Workers/Cloudflare build that means the worker fails at boot and never serves a request.

Reported in #111 against `@oxc-parser/binding-wasm32-wasi`. The reproduction there predates the in-tree reader, but the defect is in the plugin's error handling, not the decoder, so it survived the rewrite: any binary the reader declines still takes this path today.

## Fix

Let the parse failure propagate. `transform` already has the correct handler for it one frame up — the `catch` that sets `isModule = true` and warns through `this.warn` — it just never received anything.

```diff
-    try {
-      const parsed = parseWasm(source, { name });
-      ...
-    } catch (error) {
-      console.warn(...);
-    }
+    const parsed = parseWasm(source, { name });
+    ...
```

Three things follow from this, all of which were already implemented and simply unreachable:

- **Module mode is used**, handing the binary to the engine, which understands the sections and proposals the reader does not. `getWasmModuleBinding` needs no interface information at all, so it is correct for exactly the binaries the reader cannot describe.
- **The warning goes through `this.warn`** instead of `console.warn`, so it carries the module `id`, is attributed to the plugin, and respects the existing `silent` option (which `console.warn` ignored).
- **Nothing is cached on failure**, since the assignment to `_parseCache` is now after the throwing call. A second transform of the same asset re-parses and fails again rather than reading a cache entry that looks like a successful parse — relevant to watch mode and to multi-entry builds sharing an asset.

Behaviour for parsable modules is unchanged; `?module` imports and modules that genuinely declare no imports are untouched.

## Tests

`test/parse-fallback.test.ts` drives the `transform` hook over a hand-assembled binary whose import section declares kind `0x09`. Import kinds are open ended and each descriptor is kind specific, so an unknown kind leaves the reader no way to locate the next import — it is the smallest honest stand-in for the oxc binary in #111, without vendoring a 30 MB fixture.

- The emitted code is a `WebAssembly.Module` binding, and contains neither `no imports` nor `_instantiate` — i.e. the build is not wired to an interface derived from a parse that never succeeded. On `main` this assertion fails with the eager, unsatisfiable binding.
- A second transform of the same asset still falls back (pins the cache behaviour).
- `silent: true` suppresses the warning, which `console.warn` did not.

## Validation

- `vitest run` — 54 passed (3 files), including the rollup/rolldown/vite build matrix
- `oxlint . && oxfmt --check src test` — clean
- Both new assertions verified to fail on `main` before the fix

Fixes #111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unsupported WebAssembly binaries by issuing a warning and falling back to module mode instead of producing invalid results.
  * Parsing failures now propagate correctly to the transformation process, ensuring consistent fallback behavior.

* **Tests**
  * Expanded coverage for parser and engine validation, generated module compilation, exports, instantiation failures, and unsupported WebAssembly imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->